### PR TITLE
Add retry queue

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,11 @@ type S3Meta = PluginMeta<{
 }>
 type S3Plugin = Plugin<S3Meta>
 
+interface UploadJobPayload {
+    batch: PluginEvent[]
+    batchId: number
+}
+
 class UploadError extends Error {}
 class RetryQueue {
     baseInterval: number
@@ -58,11 +63,6 @@ class RetryQueue {
 
         await jobs.uploadBatchToS3({ batch, batchId: id }).runIn(nextRetryMs, 'milliseconds')
     }
-}
-
-interface UploadJobPayload {
-    batch: PluginEvent[]
-    batchId: number
 }
 
 export const jobs: PluginJobs<S3Meta> = {

--- a/index.ts
+++ b/index.ts
@@ -45,8 +45,7 @@ export const jobs: PluginJobs<S3Meta> = {
                 console.log(`Enqueued batch ${payload.batchId} for retry in ${nextRetryMs}ms`)
                 await jobs
                     .uploadBatchToS3({
-                        batch: payload.batch,
-                        batchId: payload.batchId,
+                        ...payload,
                         retriesPerformedSoFar: payload.retriesPerformedSoFar + 1,
                     })
                     .runIn(nextRetryMs, 'milliseconds')

--- a/index.ts
+++ b/index.ts
@@ -27,15 +27,13 @@ type S3Meta = PluginMeta<{
 }>
 type S3Plugin = Plugin<S3Meta>
 
-class UploadError extends Error { }
+class UploadError extends Error {}
 class RetryQueue {
     baseInterval: number
     meta: S3Meta
     requestRetriesMap: Map<number, number>
 
-    constructor(
-        meta: S3Meta
-    ) {
+    constructor(meta: S3Meta) {
         this.baseInterval = 3000 // ms
         this.meta = meta
         this.requestRetriesMap = new Map<number, number>()
@@ -55,14 +53,11 @@ class RetryQueue {
             this.requestRetriesMap.set(id, retriesPerformedSoFar + 1)
         }
 
-
-        const nextRetryMs = (2 ** retriesPerformedSoFar) * this.baseInterval
+        const nextRetryMs = 2 ** retriesPerformedSoFar * this.baseInterval
         console.log(`Enqueued batch ${id} for retry in ${nextRetryMs}ms`)
-
 
         await jobs.uploadBatchToS3({ batch, batchId: id }).runIn(nextRetryMs, 'milliseconds')
     }
-
 }
 
 interface UploadJobPayload {
@@ -82,7 +77,7 @@ export const jobs: PluginJobs<S3Meta> = {
             }
             throw err
         }
-    }
+    },
 }
 
 export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import { createBuffer } from '@posthog/plugin-contrib'
 import { S3 } from 'aws-sdk'
 import { randomBytes } from 'crypto'
 import { brotliCompressSync, gzipSync } from 'zlib'
-import { Plugin, PluginMeta } from '@posthog/plugin-scaffold'
+import { Plugin, PluginMeta, PluginEvent, PluginJobs } from '@posthog/plugin-scaffold'
 import { ManagedUpload } from 'aws-sdk/clients/s3'
 
 type S3Meta = PluginMeta<{
@@ -10,6 +10,7 @@ type S3Meta = PluginMeta<{
         s3: S3
         buffer: ReturnType<typeof createBuffer>
         eventsToIgnore: Set<string>
+        retryQueue: RetryQueue
     }
     config: {
         awsAccessKey: string
@@ -26,7 +27,66 @@ type S3Meta = PluginMeta<{
 }>
 type S3Plugin = Plugin<S3Meta>
 
-export const setupPlugin: S3Plugin['setupPlugin'] = ({ global, config }) => {
+class UploadError extends Error { }
+class RetryQueue {
+    baseInterval: number
+    meta: S3Meta
+    requestRetriesMap: Map<number, number>
+
+    constructor(
+        meta: S3Meta
+    ) {
+        this.baseInterval = 3000 // ms
+        this.meta = meta
+        this.requestRetriesMap = new Map<number, number>()
+    }
+
+    async enqueue(batch: PluginEvent[], id: number) {
+        const { jobs } = this.meta
+        let retriesPerformedSoFar = 0
+        if (!this.requestRetriesMap.has(id)) {
+            this.requestRetriesMap.set(id, 0)
+        } else {
+            retriesPerformedSoFar = this.requestRetriesMap.get(id)!
+            if (retriesPerformedSoFar === 15) {
+                this.requestRetriesMap.delete(id)
+                return
+            }
+            this.requestRetriesMap.set(id, retriesPerformedSoFar + 1)
+        }
+
+
+        const nextRetryMs = (2 ** retriesPerformedSoFar) * this.baseInterval
+        console.log(`Enqueued batch ${id} for retry in ${nextRetryMs}ms`)
+
+
+        await jobs.uploadBatchToS3({ batch, batchId: id }).runIn(nextRetryMs, 'milliseconds')
+    }
+
+}
+
+interface UploadJobPayload {
+    batch: PluginEvent[]
+    batchId: number
+}
+
+export const jobs: PluginJobs<S3Meta> = {
+    uploadBatchToS3: async (payload: UploadJobPayload, meta: S3Meta) => {
+        const { global } = meta
+        try {
+            sendBatchToS3(payload.batch, meta)
+        } catch (err) {
+            if (err.constructor === UploadError) {
+                global.retryQueue.enqueue(payload.batch, payload.batchId)
+                return
+            }
+            throw err
+        }
+    }
+}
+
+export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
+    const { global, config, jobs } = meta
     if (!config.awsAccessKey) {
         throw new Error('AWS access key missing!')
     }
@@ -49,48 +109,55 @@ export const setupPlugin: S3Plugin['setupPlugin'] = ({ global, config }) => {
         region: config.awsRegion,
     })
 
+    global.retryQueue = new RetryQueue(meta)
+
     global.buffer = createBuffer({
         limit: uploadMegabytes * 1024 * 1024,
-        timeoutSeconds: uploadMinutes * 60,
-        onFlush: (batch) => {
-            console.log(`Flushing ${batch.length} events!`)
-            const date = new Date().toISOString()
-            const [day, time] = date.split('T')
-            const dayTime = `${day.split('-').join('')}-${time.split(':').join('')}`
-            const suffix = randomBytes(8).toString('hex')
-
-            const params = {
-                Bucket: config.s3BucketName,
-                Key: `${config.prefix || ''}${day}/${dayTime}-${suffix}.jsonl`,
-                Body: Buffer.from(batch.map((event) => JSON.stringify(event)).join('\n'), 'utf8'),
-            }
-
-            if (config.compression === 'gzip') {
-                params.Key = `${params.Key}.gz`
-                params.Body = gzipSync(params.Body)
-            }
-
-            if (config.compression === 'brotli') {
-                params.Key = `${params.Key}.br`
-                params.Body = brotliCompressSync(params.Body)
-            }
-            global.s3.upload(params, (err: Error, data: ManagedUpload.SendData) => {
-                if (err) {
-                    console.error(`Error uploading to S3: ${err.message}`)
-                    throw err
-                }
-                console.log(`Uploaded ${batch.length} event${batch.length === 1 ? '' : 's'} to ${data.Location}`)
-            })
+        timeoutSeconds: uploadMinutes,
+        onFlush: async (batch) => {
+            await jobs.uploadBatchToS3({ batch, batchId: Math.floor(Math.random() * 1000000) }).runNow()
         },
     })
+
     global.eventsToIgnore = new Set(
         config.eventsToIgnore ? config.eventsToIgnore.split(',').map((event) => event.trim()) : null
     )
 }
 
-export const processEvent: S3Plugin['processEvent'] = (event, { global }) => {
+export const onEvent = (event: PluginEvent, { global }: S3Meta) => {
     if (!global.eventsToIgnore.has(event.event)) {
         global.buffer.add(event)
     }
-    return event
+}
+
+export const sendBatchToS3 = (batch: PluginEvent[], { global, config }: S3Meta) => {
+    const date = new Date().toISOString()
+    const [day, time] = date.split('T')
+    const dayTime = `${day.split('-').join('')}-${time.split(':').join('')}`
+    const suffix = randomBytes(8).toString('hex')
+
+    const params = {
+        Bucket: config.s3BucketName,
+        Key: `${config.prefix || ''}${day}/${dayTime}-${suffix}.jsonl`,
+        Body: Buffer.from(batch.map((event) => JSON.stringify(event)).join('\n'), 'utf8'),
+    }
+
+    if (config.compression === 'gzip') {
+        params.Key = `${params.Key}.gz`
+        params.Body = gzipSync(params.Body)
+    }
+
+    if (config.compression === 'brotli') {
+        params.Key = `${params.Key}.br`
+        params.Body = brotliCompressSync(params.Body)
+    }
+
+    console.log(`Flushing ${batch.length} events!`)
+    global.s3.upload(params, (err: Error, data: ManagedUpload.SendData) => {
+        if (err) {
+            console.error(`Error uploading to S3: ${err.message}`)
+            throw new UploadError()
+        }
+        console.log(`Uploaded ${batch.length} event${batch.length === 1 ? '' : 's'} to ${data.Location}`)
+    })
 }

--- a/index.ts
+++ b/index.ts
@@ -108,7 +108,7 @@ export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
 
     global.buffer = createBuffer({
         limit: uploadMegabytes * 1024 * 1024,
-        timeoutSeconds: uploadMinutes,
+        timeoutSeconds: uploadMinutes * 60,
         onFlush: async (batch) => {
             await jobs.uploadBatchToS3({ batch, batchId: Math.floor(Math.random() * 1000000) }).runNow()
         },

--- a/index.ts
+++ b/index.ts
@@ -41,7 +41,7 @@ export const jobs: PluginJobs<S3Meta> = {
             sendBatchToS3(payload.batch, meta)
         } catch (err) {
             if (err.constructor === UploadError && payload.retriesPerformedSoFar < 15) {
-                const nextRetryMs = 2 ** payload.retriesPerformedSoFar * 3000 // here
+                const nextRetryMs = 2 ** payload.retriesPerformedSoFar * 3000 
                 console.log(`Enqueued batch ${payload.batchId} for retry in ${nextRetryMs}ms`)
                 await jobs
                     .uploadBatchToS3({
@@ -83,7 +83,7 @@ export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
 
     global.buffer = createBuffer({
         limit: uploadMegabytes * 1024 * 1024,
-        timeoutSeconds: uploadMinutes * 60, // here
+        timeoutSeconds: uploadMinutes * 60, 
         onFlush: async (batch) => {
             await jobs.uploadBatchToS3({ batch, batchId: Math.floor(Math.random() * 1000000), retriesPerformedSoFar: 0 }).runNow()
         },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Export PostHog events to Amazon S3 on ingestion.",
     "devDependencies": {
         "@posthog/plugin-contrib": "^0.0.3",
-        "@posthog/plugin-scaffold": "^0.7.1",
+        "@posthog/plugin-scaffold": "^0.9.0",
         "@types/generic-pool": "^3.1.9",
         "aws-sdk": "^2.885.0",
         "generic-pool": "^3.7.8"

--- a/plugin.json
+++ b/plugin.json
@@ -65,7 +65,7 @@
             "key": "eventsToIgnore",
             "name": "Events to ignore",
             "type": "string",
-            "default": "$snapshot, $feature_flag_called",
+            "default": "$feature_flag_called",
             "hint": "Comma separated list of events to ignore"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.3.tgz#d0772c6dd9ec9944ebee9dc475e1e781256b0b5f"
   integrity sha512-0HrE8AuPv3OLZA93RrJDbljn9u5D/wmiIkBCeckU3LL67LNozDIJgKsY4Td91zgc+b4Rlx/X0MJNp2l6BHbQqg==
 
-"@posthog/plugin-scaffold@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.7.1.tgz#801dce0d55e77851fc054bd8a6284de78b90f0a3"
-  integrity sha512-QkMkNpyGWLen6FCmPjpHmUsalHa8e5/6eenUS/vG4SKWMORod0VDVlDYnInUXzS+HYhIjKSlgprwAyCp+2KWfQ==
+"@posthog/plugin-scaffold@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.9.0.tgz#67f1eaeb526591ed6693dce2fd2eeb6a7ff69546"
+  integrity sha512-JvxTpIUsCzJcRqeEtQiAsigXyzG5fMqH0zEadEPsqfPZoznIzeNGCu37AyMewOJzId+zlgmRz1R7O1kqhbyPZg==
   dependencies:
     "@maxmind/geoip2-node" "^2.3.1"
 


### PR DESCRIPTION
Adds a retry queue with exponential backoff, moves to `onEvent` instead of `processEvent`. Closes #5 

Wondering if we want the interval configurable? I'd personally say no.

Last retry will happen in around 27h:

| Retries performed already | Seconds until retry |
| :----: | :----: |
| 0 | 0  |
| 1 | 3  |
| 2 | 9  |
| 3 | 21  |
| 4 | 45  |
| 5 | 93  |
| 6 | 189  |
| 7 | 381  |
| 8 | 765  |
| 9 | 1533  |
| 10 | 3069  |
| 11 | 6141  |
| 12 | 12285  |
| 13 | 24573  |
| 14 | 49149  |
| 15 | 98301  |