### PR TITLE
add support for setting s3 bucket endpoint

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ type S3Plugin = Plugin<{
         awsSecretAccessKey: string
         awsRegion: string
         s3BucketName: string
+        s3BucketEndpoint: string
         prefix: string
         uploadMinutes: string
         uploadMegabytes: string
@@ -58,11 +59,20 @@ export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
     const uploadMegabytes = Math.max(1, Math.min(parseInt(config.uploadMegabytes) || 1, 100))
     const uploadMinutes = Math.max(1, Math.min(parseInt(config.uploadMinutes) || 1, 60))
 
-    global.s3 = new S3({
+    const s3Config = {
         accessKeyId: config.awsAccessKey,
         secretAccessKey: config.awsSecretAccessKey,
         region: config.awsRegion,
-    })
+	signatureVersion: 'v4',
+    }
+
+    if (config.s3BucketEndpoint) {
+	s3Config.s3BucketEndpoint = true
+	s3Config.s3ForcePathStyle = true
+	s3Config.endpoint = config.s3BucketEndpoint
+    }
+
+    global.s3 = new S3(s3Config)
 
     global.buffer = createBuffer({
         limit: uploadMegabytes * 1024 * 1024,

--- a/index.ts
+++ b/index.ts
@@ -67,8 +67,6 @@ export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
     }
 
     if (config.s3BucketEndpoint) {
-	s3Config.s3BucketEndpoint = true
-	s3Config.s3ForcePathStyle = true
 	s3Config.endpoint = config.s3BucketEndpoint
     }
 

--- a/plugin.json
+++ b/plugin.json
@@ -31,6 +31,14 @@
             "required": true
         },
         {
+            "key": "s3BucketEndpoint",
+            "name": "S3 Bucket Endpoint",
+            "type": "string",
+            "default": "",
+	    "hint": "For example \"http://127.0.0.1:9000\", which is minio or localstack instance with API compatible with Amazon S3",
+            "required": false
+        },
+        {
             "key": "s3BucketName",
             "name": "S3 Bucket name",
             "type": "string",


### PR DESCRIPTION
Our company is using both S3 (on AWS) and OSS (on Alibaba Cloud). OSS has API compatible with Amazon S3, but we need to set appropriate endpoint with OSS when using aws s3 sdk.

So it will be really helpful for those users who use object storage PaaS, which has API compatible with Amazon S3.