### PR TITLE
Allow server-side encryption

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -58,7 +58,7 @@ export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
     if (!config.s3BucketName) {
         throw new Error('S3 bucket name missing!')
     }
-    if (config.sse === 'aws:kms' && config.sseKmsKeyId === '') {
+    if (config.sse === 'aws:kms' && !config.sseKmsKeyId) {
         throw new Error('AWS KMS encryption requested but not KMS key ID provided!')
     }
 

--- a/index.ts
+++ b/index.ts
@@ -59,7 +59,7 @@ export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
         throw new Error('S3 bucket name missing!')
     }
     if (config.sse === 'aws:kms' && !config.sseKmsKeyId) {
-        throw new Error('AWS KMS encryption requested but not KMS key ID provided!')
+        throw new Error('AWS KMS encryption requested but no KMS key ID provided!')
     }
 
     const uploadMegabytes = Math.max(1, Math.min(parseInt(config.uploadMegabytes) || 1, 100))

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,9 @@ type S3Plugin = Plugin<{
         eventsToIgnore: string
         uploadFormat: 'jsonl'
         compression: 'gzip' | 'brotli' | 'no compression'
-        signatureVersion: '' | 'v4'
+        signatureVersion: '' | 'v4',
+        sse: 'disabled' | 'AES256' | 'aws:kms',
+        sseKmsKeyId: string
     }
     jobs: {
         uploadBatchToS3: UploadJobPayload
@@ -55,6 +57,9 @@ export const setupPlugin: S3Plugin['setupPlugin'] = (meta) => {
     }
     if (!config.s3BucketName) {
         throw new Error('S3 bucket name missing!')
+    }
+    if (config.sse === 'aws:kms' && config.sseKmsKeyId === '') {
+        throw new Error('AWS KMS encryption requested but not KMS key ID provided!')
     }
 
     const uploadMegabytes = Math.max(1, Math.min(parseInt(config.uploadMegabytes) || 1, 100))
@@ -115,6 +120,14 @@ export const sendBatchToS3 = async (payload: UploadJobPayload, meta: PluginMeta<
     if (config.compression === 'brotli') {
         params.Key = `${params.Key}.br`
         params.Body = brotliCompressSync(params.Body)
+    }
+
+    if (config.sse !== 'disabled') {
+        params.ServerSideEncryption = config.sse
+    }
+
+    if (config.sse === 'aws:kms') {
+        params.SSEKMSKeyId = config.sseKmsKeyId
     }
 
     console.log(`Flushing ${batch.length} events!`)

--- a/plugin.json
+++ b/plugin.json
@@ -99,6 +99,22 @@
             "choices": ["v4", ""],
             "default": "",
             "hint": "[Docs](https://docs.aws.amazon.com/AmazonS3/latest/API/bucket-policy-s3-sigv4-conditions.html)"
+        },
+        {
+            "key": "sse",
+            "name": "Server-side encryption",
+            "type": "choice",
+            "choices": ["disabled", "AES256", "aws:kms"],
+            "default": "disabled",
+            "hint": "Specifies server-side encryption of the object in S3. Valid values are AES256 and aws:kms. If the parameter is specified but no value is provided, AES256 is used."
+        },
+        {
+            "key": "sseKmsKeyId",
+            "name": "SSE KMS key ID",
+            "type": "string",
+            "default": "",
+            "hint": "The customer-managed AWS Key Management Service (KMS) key ID that should be used to server-side encrypt the object in S3.",
+            "required": false
         }
     ]
 }


### PR DESCRIPTION
This adds the possibility to enable AWS S3 server-side encryption.

You can either use `AES256` to use the AWS S3 managed encryption or
`aws:kms` and specify your own KMS key.